### PR TITLE
_hostgroups search similar to _hosts search

### DIFF
--- a/recipes/_hostgroups.rb
+++ b/recipes/_hostgroups.rb
@@ -21,7 +21,7 @@ node['shinken']['hostgroups'].each do |hg_name, hg_conf|
   if hg_conf['search_str']
     conf['members'] = search(
       :node,
-      "chef_environment:#{node.chef_environment} AND " + hg_conf['search_str']
+      node['shinken']['host_search_query'] + " AND " + hg_conf['search_str']
     ).map(&:name).join(',')
   elsif hg_conf['members']
     conf['members'] = hg_conf['members'].join(',')


### PR DESCRIPTION
Let's say that you would like to have a shinken server in the "production" environment that monitors ALL servers including "testing" servers.

That is possible with this attribute currently:

```ruby
default['shinken']['host_search_query'] = "chef_environment:#{node.chef_environment}"
```

However, `_hostgroups` still has `"chef_environment:#{node.chef_environment}"` hardcoded in the recipe. Shouldn't it also use the `host_search_query` variable? So, that is the pull request.