### PR TITLE
Update RuboCop config as per error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,5 +6,5 @@ LineLength:
   Max: 100
 
 # Lining up the attributes of some methods is advantageous for readability
-SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false


### PR DESCRIPTION
As of a recent version of rubocop/cookstyle, this is now an error:

```
Error: The `Style/SingleSpaceBeforeFirstArg` cop has been renamed to `Style/SpaceBeforeFirstArg.
```