### PR TITLE
Make the Pagerduty & Slack handlers optional

### DIFF
--- a/attributes/handlers.rb
+++ b/attributes/handlers.rb
@@ -1,0 +1,2 @@
+default['shinken']['handlers']['pagerduty'] = {}
+default['shinken']['handlers']['slack'] = {}

--- a/recipes/_handlers.rb
+++ b/recipes/_handlers.rb
@@ -25,5 +25,5 @@ directory '/etc/shinken/notification-handlers' do
   group  'shinken'
 end
 
-include_recipe 'shinken::pagerduty_handler'
-include_recipe 'shinken::slack_handler'
+include_recipe 'shinken::pagerduty_handler' if node['shinken']['handlers']['pagerduty']
+include_recipe 'shinken::slack_handler' if node['shinken']['handlers']['slack']


### PR DESCRIPTION
Set the default to true, to maintain backwards compatibility & avoid this being a breaking change.

@eherot?