### PR TITLE
Add empty defaults for services & hostgroups

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,3 +10,6 @@ default['shinken']['source_checksum'] =
 
 default['shinken']['agent_key_data_bag'] = 'secrets'
 default['shinken']['agent_key_data_bag_item'] = 'monitoring'
+
+default['shinken']['services'] = {}
+default['shinken']['hostgroups'] = {}


### PR DESCRIPTION
Since neither of these are checked for values before they are used, leaving them unset causes the cookbook to fail to converge.

However, the cookbook will converge properly without them set. This ensures that is possible.

@eherot, a minor thing; I ran into this when I wrapped the cookbook, but had yet to set these attribute yet.