### PR TITLE
Limit builds to just master and pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ cache:
   directories:
   - "$HOME/.berkshelf"
 rvm: 2.3
+branches:
+  only:
+  - master
 addons:
   apt:
     sources:


### PR DESCRIPTION
With Travis CI set to build pushes & pull requests, the addition of this config means it will only build:

* Pull requests
* Pushes to master (including merges of PRs)

@eherot?

Which cleans up the testing and avoids double-testing of PRs