### PR TITLE
Use cookstyle for more Chef-friendly Ruby linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ install:
 - berks
 before_script:
 - chef --version
-- rubocop --version
+- cookstyle --version
 - foodcritic --version
 script:
-- rubocop
+- cookstyle
 - foodcritic .
 - chef exec rspec
 - kitchen test ${SUITE} -d always


### PR DESCRIPTION
A much more meaningful set of rules in the realm of Chef-fy Ruby.

@eherot, this should quiet down Travis a little bit, and provide more meaningful lint rules to adhere to.